### PR TITLE
Corrected argument order when constructing OpenFlow 1.0 PacketIn message

### DIFF
--- a/examples/switch/datapath.cc
+++ b/examples/switch/datapath.cc
@@ -40,7 +40,7 @@ void Datapath::action_handler(Action *act, struct packet *pkt){
  					Datapath::buffer_id++;
  					this->pkt_buffer.insert(std::pair<uint32_t,struct packet*>(Datapath::buffer_id,pkt));
  					uint16_t max_len = pkt->len > oa->max_len()? oa->max_len():pkt->len;
- 					of10::PacketIn pi(21,  -1, pkt->len, pkt->in_port, of10::OFPR_ACTION);
+ 					of10::PacketIn pi(21,  -1, pkt->in_port, pkt->len, of10::OFPR_ACTION);
 			 		pi.data(pkt->data, max_len);
 			 		uint8_t* buffer  = pi.pack();
 			 		(*(this->conn))->send(buffer, pi.length());

--- a/examples/switch/port.cc
+++ b/examples/switch/port.cc
@@ -67,7 +67,7 @@ void SwPort::packet_handler(u_char *user, const struct pcap_pkthdr* pkthdr,const
 		//No -> Send to controller
 		if(*(*(pcap_dp->dp))->conn != NULL){					
 			// /*TODO: generate xid function*/
-			of10::PacketIn pi(21,  Datapath::buffer_id, pkthdr->len, pkt->in_port, of10::OFPR_NO_MATCH);
+			of10::PacketIn pi(21,  Datapath::buffer_id, pkt->in_port, pkthdr->len, of10::OFPR_NO_MATCH);
 	 		pi.data(pkt->data, pkt->len);
 	 		uint8_t* buffer  = pi.pack();
 	 		(*(*(pcap_dp->dp))->conn)->send(buffer, pi.length());


### PR DESCRIPTION
Input port and packet length were exchanged when constructing OpenFlow 1.0 PacketIn message in the _switch_ example.
