### PR TITLE
Update libfluid_msg_of10.i

### DIFF
--- a/examples/java/swig/libfluid_msg_of10.i
+++ b/examples/java/swig/libfluid_msg_of10.i
@@ -7,6 +7,7 @@ typedef unsigned int of_error;
 
 %include "stdint.i"
 %include "various.i"
+%include "std_vector.i"
 
 %typemap(jni)    (uint8_t *) "jbyteArray"
 %typemap(jni)    (void *) "jbyteArray"
@@ -14,6 +15,7 @@ typedef unsigned int of_error;
 %typemap(jtype)  (void *) "byte[]"
 %typemap(jstype) (uint8_t *) "byte[]"
 %typemap(jstype) (void *) "byte[]"
+%template(Ports_) std::vector<fluid_msg::of10::Port>;
 
 %typemap(in) void* {
     $1 = (void *) JCALL2(GetByteArrayElements, jenv, $input, 0);


### PR DESCRIPTION
Debido a que Swig no lee la variable std::vector necesitaba añadirle la libreria y ademas asignarle la opcion para que no creara una clase swigtype_p_std_vectorT_fluid_msg_of10_port_t en java si no una clase "Ports_" de la cual puedo obtener mediante un ciclo, los puertos del switch